### PR TITLE
Fix Questa 22.2 installation

### DIFF
--- a/Dockerfile-Full
+++ b/Dockerfile-Full
@@ -3,7 +3,7 @@ FROM mluckydwyer/hw-ci:slim as slim
 
 LABEL \
     org.opencontainers.image.title="Hardware Verification CI Docker container" \
-    org.opencontainers.image.description="Modelsim, Verilator, GHDL, VUnit, CocoTB, and Pytest for HW Development (+VNC)." \
+    org.opencontainers.image.description="Questa Sim, Verilator, GHDL, VUnit, CocoTB, and Pytest for HW Development (+VNC)." \
     org.opencontainers.image.authors="Matthew Dwyer <dwyer@iastate.edu>" \
     org.opencontainers.image.source="https://github.com/Mluckydwyer/hw-ci"
 
@@ -30,10 +30,11 @@ WORKDIR /tmp
 ENV QUESTA_VERSION=22.2
 ENV QUESTA_VERSION_FULL=22.2.0.94
 RUN curl -sS -O https://downloads.intel.com/akdlm/software/acdsinst/22.2/94/ib_installers/QuestaSetup-22.2.0.94-linux.run \
-    && chmod +x ModelSimSetup-${QUESTA_VERSION_FULL}-linux.run \
-    && ./QuestaSetup-${QUESTA_VERSION_FULL}-linux.run --mode unattended --installdir /opt/intelFPGA/${QUESTA_VERSION} --accept_eula 1 --questa_edition questa_ase \
+    && curl -sS -O https://downloads.intel.com/akdlm/software/acdsinst/22.2/94/ib_installers/questa_part2-22.2.0.94-linux.qdz \
+    && chmod +x QuestaSetup-${QUESTA_VERSION_FULL}-linux.run \
+    && ./QuestaSetup-${QUESTA_VERSION_FULL}-linux.run --mode unattended --installdir /opt/intelFPGA/${QUESTA_VERSION} --accept_eula 1 --questa_edition questa_fse \
     && rm QuestaSetup-${QUESTA_VERSION_FULL}-linux.run
-ENV PATH="/opt/intelFPGA/${QUESTA_VERSION}/questa_ase/bin:${PATH}"
+ENV PATH="/opt/intelFPGA/${QUESTA_VERSION}/questa_fse/bin:${PATH}"
 
 
 # Install Symbiflow toolchain

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This container is split into three variants, `slim`, `full`, and `dev`. The `sli
 
 ### 📜 Helper Scripts
 Here is a list of the included helper scripts in the `full` and `dev` containers. They are included on the system path and can be run from anyhere:
-- `start-modelsim`: Open Modelsim in GUI mode.
+- `start-modelsim`: Open Questa in GUI mode. The `LM_LICENCE_FILE` environment variable must contain the path to the license file you obtained from Intel.
 - `start-vnc-session`: Start the NoVNC server (VNC can be accessed on port 5090, NoVNC webserver can be accessed at localhost:6080 @1080p).
 - `start-code-server`: Start the VSCode remote server (Can also be done by opening the container in VSCode).
 - `enable-symbiflow-xc7`: Activate the Symbiflow XC7 Conda envrionment

--- a/resources/start-modelsim.sh
+++ b/resources/start-modelsim.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/opt/intelFPGA/20.1/modelsim_ase/bin/vsim &> /tmp/modelsim.log
+/opt/intelFPGA/22.2/questa_fse/bin/vsim &> /tmp/modelsim.log


### PR DESCRIPTION
Questa now requires two separate files as installer.

What remains to be done is to properly handle passing the license file to the container:

To run the system the current command would be:

```shell
docker run -v <path to license>:/license.dat -e LM_LICENSE_FILE=/license.dat --mac-address=<chosen mac> <cmd>
```

where the mac address needs to be provided as NIC ID when obtaining a license from Intel. To force the MAC address in a Gitlab Runner container, there is a [workaround](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2344) (disclaimer: I did not test it).